### PR TITLE
removed incorrect slot args handling for signal

### DIFF
--- a/pizco/util.py
+++ b/pizco/util.py
@@ -31,8 +31,7 @@ class Signal(object):
     def emit(self, *args):
         #thread safety in qt main loop maybe pyqtSignals should be called behind
         for slot in self.slots:
-            argcount = slot.__code__.co_argcount
-            slot(*args[:argcount-1])
+            slot(*args)
 
 def bind(sock, endpoint='tcp://127.0.0.1:0'):
     """Bind socket to endpoint accepting a variety of endpoint formats.


### PR DESCRIPTION
The commit 89d5e13be567128f96a7b28cfd74bb29a80bb70c introduced a bug where args would be dropped when passing through signals.

It looks like @PierreBizouard partially fixed this in his branch. However, his branch still doesn't handle variable args (*args) properly.

Perhaps it would be better to subclass Signal?
