### PR TITLE
New Signal Class & Agent.notifications_callback unsubscribe bugfix

### DIFF
--- a/pizco/__init__.py
+++ b/pizco/__init__.py
@@ -25,6 +25,7 @@ if (zmq.zmq_version_info()[0] < 3):
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
 
+
 def main(args=None):
     import argparse
     parser = argparse.ArgumentParser('Starts an server')

--- a/pizco/agent.py
+++ b/pizco/agent.py
@@ -368,6 +368,7 @@ class Agent(object):
         except:
             LOGGER.debug('Invalid message {}'.format(message))
         else:
+            # TODO why does this someties cause a KeyError
             callback = self.notifications_callbacks[(sender, topic)]
             if callback:
                 callback(sender, topic, content, msgid)

--- a/pizco/agent.py
+++ b/pizco/agent.py
@@ -368,8 +368,7 @@ class Agent(object):
         except:
             LOGGER.debug('Invalid message {}'.format(message))
         else:
-            # TODO why does this someties cause a KeyError
-            callback = self.notifications_callbacks[(sender, topic)]
+            callback = self.notifications_callbacks.get((sender, topic), None)
             if callback:
                 callback(sender, topic, content, msgid)
             else:

--- a/pizco/clientserver.py
+++ b/pizco/clientserver.py
@@ -302,6 +302,8 @@ class ProxyAgent(Agent):
 
         LOGGER.debug('Started Proxy pointing to REP: {} and PUB: {}'.format(self.remote_rep_endpoint, self.remote_pub_endpoint))
         self._signals = defaultdict(Signal)
+        # TODO how to inspect remote signal to get spec
+
 
         #: Maps msgid to future object.
         self._futures = {}

--- a/pizco/clientserver.py
+++ b/pizco/clientserver.py
@@ -80,8 +80,11 @@ class RemoteAttribute(object):
     def disconnect(self, fun):
         self.signal_manager('disconnect', self.name, fun)
 
-    def emit(self, value, old_value, other):
-        self.signal_manager('emit', self.name, (value, old_value, other))
+    #def emit(self, value, old_value, other):
+    #    self.signal_manager('emit', self.name, (value, old_value, other))
+
+    def emit(self, *args, **kwargs):
+        self.signal_manager('emit', self.name, (args, kwargs))
 
 
 def PSMessage(action, options):
@@ -189,9 +192,13 @@ class Server(Agent):
             tb = traceback.format_exception(exc_type, exc_value, exc_tb)[1:]
             return PSMessage('raise', (ex, tb))
 
-    def emit(self, topic, value, old_value, other):
-        LOGGER.debug('Emitting {}, {}, {}, {}'.format(topic, value, old_value, other))
-        self.publish(topic, (value, old_value, other))
+    #def emit(self, topic, value, old_value, other):
+    #    LOGGER.debug('Emitting {}, {}, {}, {}'.format(topic, value, old_value, other))
+    #    self.publish(topic, (value, old_value, other))
+
+    def emit(self, topic, *args, **kwargs):
+        LOGGER.debug('Emitting {}, {}, {}'.format(topic, args, kwargs))
+        self.publish(topic, (args, kwargs))
 
     def on_subscribe(self, topic, count):
         try:
@@ -201,9 +208,13 @@ class Server(Agent):
 
         if count == 1:
             LOGGER.debug('Connecting {} signal on server'.format(topic))
-            def fun(value, old_value=None, other=None):
+            #def fun(value, old_value=None, other=None):
+            #    LOGGER.debug('ready to emit')
+            #    self.emit(topic, value, old_value, other)
+
+            def fun(*args, **kwargs):
                 LOGGER.debug('ready to emit')
-                self.emit(topic, value, old_value, other)
+                self.emit(topic, *args, **kwargs)
             self.signal_calls[topic] = fun
             signal.connect(self.signal_calls[topic])
 

--- a/pizco/util.py
+++ b/pizco/util.py
@@ -31,8 +31,7 @@ class Signal(object):
     def emit(self, *args):
         #thread safety in qt main loop maybe pyqtSignals should be called behind
         for slot in self.slots:
-            argcount = slot.__code__.co_argcount
-            slot(*args[:argcount-1])
+            slot(*args)
 
 def bind(sock, endpoint='tcp://127.0.0.1:0'):
     """Bind socket to endpoint accepting a variety of endpoint formats.

--- a/pizco/util.py
+++ b/pizco/util.py
@@ -12,18 +12,75 @@
 import inspect
 
 
+class SignalError(Exception):
+    pass
+
+
+def getspec(f):
+    spec = inspect.getargspec(f)
+    defaults = []
+    if spec.defaults is not None:
+        defaults = spec.defaults
+    return inspect.ArgSpec(
+        spec.args, spec.varargs is not None,
+        spec.keywords is not None, defaults)
+
+
 class Signal(object):
     """PyQt like signal object
     """
-    def __init__(self):
+    def __init__(self, nargs=0, kwargs=None, varargs=False, varkwargs=False):
         # add dummy types for signals or hide a pyqtSignal behind to resync
         # with qt main loop
         self.slots = []
+        self._nargs = nargs
+        if kwargs is None:
+            self._kwargs = []
+        else:
+            self._kwargs = kwargs
+        self._varargs = varargs
+        self._varkwargs = varkwargs
+
+    def _verify_slot(self, slot):
+        # signal varags -> slot varargs
+        # signal args -> slot args (or varargs)
+        # signal kwargs -> slot kwargs
+        spec = getspec(slot)
+
+        if not spec.varargs:  # function expects args
+            if self._varargs:
+                raise SignalError(
+                    "Slot {} does not accept varargs".format(slot))
+            else:  # check nargs
+                maxargs = len(spec.args)
+                if maxargs < self._nargs:
+                    raise SignalError(
+                        "Slot {} does not accept enough args {}".format(
+                            slot, maxargs))
+                minargs = maxargs - len(spec.defaults)
+                if minargs > self._nargs:
+                    raise SignalError(
+                        "Slot {} expects too many args {}".format(
+                            slot, minargs))
+
+        if not spec.keywords:  # function only accepts specific kwargs
+            if self._varkwargs:
+                raise SignalError(
+                    "Slot {} does not accept varkwargs".format(slot))
+            else:  # signal only passes specific kwargs
+                kwargs = spec.args[::-1][:len(spec.defaults)]
+                for kw in self._kwargs:
+                    if kw not in kwargs:
+                        raise SignalError(
+                            "Slot {} does not accept keyword {}".format(
+                                slot, kw))
 
     def connect(self, slot):
         # add dummy connection type maybe this the place to create the
         # pyqtSignals to be able to resync with qt event loop
         if slot not in self.slots:
+            # verify that this slot works
+            self._verify_slot(slot)
             self.slots.append(slot)
 
     def disconnect(self, slot=None):
@@ -32,15 +89,25 @@ class Signal(object):
         else:
             self.slots.remove(slot)
 
-    def emit(self, *args):
+    def _verify_emit(self, args, kwargs):
+        if not self._varargs:  # check args
+            if len(args) != self._nargs:
+                raise SignalError(
+                    "emit called with invalid number of args {}".format(
+                        len(args)))
+        if not self._varkwargs:  # check kwargs
+            for k in kwargs:
+                if k not in self._kwargs:
+                    raise SignalError(
+                        "emit called with invalid kwarg {}".format(
+                            k))
+
+    def emit(self, *args, **kwargs):
         # thread safety in qt main loop maybe pyqtSignals should be
         # called behind
+        self._verify_emit(args, kwargs)
         for slot in self.slots:
-            spec = inspect.getargspec(slot)
-            if spec.varargs is None:
-                slot(*args[:len(spec.args)])
-            else:
-                slot(*args)
+            slot(*args, **kwargs)
 
 
 def bind(sock, endpoint='tcp://127.0.0.1:0'):

--- a/pizco/util.py
+++ b/pizco/util.py
@@ -16,14 +16,32 @@ class SignalError(Exception):
     pass
 
 
+def specable(f):
+    try:
+        inspect.getargspec(f)
+        return True
+    except:
+        return False
+
+
 def getspec(f):
-    spec = inspect.getargspec(f)
-    defaults = []
-    if spec.defaults is not None:
-        defaults = spec.defaults
-    return inspect.ArgSpec(
-        spec.args, spec.varargs is not None,
-        spec.keywords is not None, defaults)
+    # TODO handle callable objects and partials
+    if specable(f):
+        spec = inspect.getargspec(f)
+        defaults = []
+        if spec.defaults is not None:
+            defaults = spec.defaults
+        return inspect.ArgSpec(
+            spec.args, spec.varargs is not None,
+            spec.keywords is not None, defaults)
+    if hasattr(f, '__call__') and specable(f.__call__):
+        spec = getspec(f.__call__)
+        args = spec.args[1:]  # remove reference to self
+        return inspect.ArgSpec(
+            args, spec.varargs, spec.keywords, spec.defaults)
+    raise ValueError(
+        "getspec doesn't know how to get function spec from type {}".format(
+            type(f)))
 
 
 class Signal(object):

--- a/pizco/util.py
+++ b/pizco/util.py
@@ -25,7 +25,6 @@ def specable(f):
 
 
 def getspec(f):
-    # TODO handle callable objects and partials
     if specable(f):
         spec = inspect.getargspec(f)
         defaults = []
@@ -39,6 +38,7 @@ def getspec(f):
         args = spec.args[1:]  # remove reference to self
         return inspect.ArgSpec(
             args, spec.varargs, spec.keywords, spec.defaults)
+    # TODO handle partials
     raise ValueError(
         "getspec doesn't know how to get function spec from type {}".format(
             type(f)))

--- a/pizco/util.py
+++ b/pizco/util.py
@@ -9,16 +9,20 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import inspect
+
 
 class Signal(object):
     """PyQt like signal object
     """
     def __init__(self):
-        #add dummy types for signals or hide a pyqtSignal behind to resync with qt main loop
+        # add dummy types for signals or hide a pyqtSignal behind to resync
+        # with qt main loop
         self.slots = []
 
     def connect(self, slot):
-        #add dummy connection type maybe this the place to create the pyqtSignals to be able to resync with qt event loop
+        # add dummy connection type maybe this the place to create the
+        # pyqtSignals to be able to resync with qt event loop
         if slot not in self.slots:
             self.slots.append(slot)
 
@@ -29,9 +33,15 @@ class Signal(object):
             self.slots.remove(slot)
 
     def emit(self, *args):
-        #thread safety in qt main loop maybe pyqtSignals should be called behind
+        # thread safety in qt main loop maybe pyqtSignals should be
+        # called behind
         for slot in self.slots:
-            slot(*args)
+            spec = inspect.getargspec(slot)
+            if spec.varargs is None:
+                slot(*args[:len(spec.args)])
+            else:
+                slot(*args)
+
 
 def bind(sock, endpoint='tcp://127.0.0.1:0'):
     """Bind socket to endpoint accepting a variety of endpoint formats.

--- a/tests/test_pizco.py
+++ b/tests/test_pizco.py
@@ -271,7 +271,6 @@ class AgentTest(unittest.TestCase):
         self.assertEqual(s.served_object.dict_attribute[1], 2)
         self.assertEqual(proxy.dict_attribute[1], 2)
         self.assertRaises(KeyError, operator.getitem, proxy.dict_attribute, 2)
-        print(proxy.dict_attribute)
         proxy.dict_attribute[2] = 4
         self.assertEqual(s.served_object.dict_attribute[2], 4)
         self.assertEqual(proxy.dict_attribute[2], 4)
@@ -437,9 +436,10 @@ class AgentTest(unittest.TestCase):
             def __init__(self_):
                 self_.called = 0
 
-            def __call__(self_, value, old_value, others):
+            #def __call__(self_, value, old_value, others):
+            #    self_.called += 1
+            def __call__(self_, value):
                 self_.called += 1
-
 
         fun1 = MemMethod()
         self.assertEqual(fun1.called, 0)
@@ -485,6 +485,7 @@ class AgentTest(unittest.TestCase):
         proxy._proxy_stop_me()
 
     def test_signal_two_proxies(self):
+        return
 
         address = 'tcp://127.0.0.1:6009'
 

--- a/tests/test_pizco.py
+++ b/tests/test_pizco.py
@@ -36,7 +36,7 @@ class Add1(Agent):
 class NoInspectServer(Server):
 
     def inspect(self):
-        return set(), set()
+        return set(), set(), set()
 
 
 class ReturnDictsServer(Server):
@@ -45,6 +45,9 @@ class ReturnDictsServer(Server):
         return isinstance(attr, dict)
 
     def return_as_remote(self, attr):
+        return False
+
+    def is_signal(self, attr):
         return False
 
 
@@ -450,7 +453,7 @@ class AgentTest(unittest.TestCase):
         proxy.rw_prop = 28
         time.sleep(SLEEP_SECS)
         self.assertEqual(proxy.rw_prop, 28)
-        self.assertEqual(fun1.called, 1)
+        self.assertEqual(fun1.called, 1)  # fail?
 
         fun2 = MemMethod()
         self.assertEqual(fun2.called, 0)
@@ -485,7 +488,6 @@ class AgentTest(unittest.TestCase):
         proxy._proxy_stop_me()
 
     def test_signal_two_proxies(self):
-        return
 
         address = 'tcp://127.0.0.1:6009'
 
@@ -499,7 +501,9 @@ class AgentTest(unittest.TestCase):
             def __init__(self_):
                 self_.called = 0
 
-            def __call__(self_, value, old_value, others):
+            #def __call__(self_, value, old_value, others):
+            #    self_.called += 1
+            def __call__(self_, value):
                 self_.called += 1
 
         fun = MemMethod()

--- a/tests/test_pizco.py
+++ b/tests/test_pizco.py
@@ -58,8 +58,8 @@ class Example(object):
         self._rw_prop = 42
         self._ro_prop = 42
         self._wo_prop = 42
-        self.rw_prop_changed = Signal()
-        self.wo_prop_changed = Signal()
+        self.rw_prop_changed = Signal(nargs=1)
+        self.wo_prop_changed = Signal(nargs=1)
 
 
     @property

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,7 +15,7 @@ class MockSocket(object):
 
 class Example(object):
     def __init__(self):
-        self.signal = Signal()
+        self.signal = Signal(varargs=True)
 
     def emit(self, *args):
         self.signal.emit(*args)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from pizco.util import bind, Signal
+from pizco.util import bind, Signal, SignalError
 
 
 class MockSocket(object):
@@ -33,28 +33,156 @@ class TestProtocol(unittest.TestCase):
 
 
 class TestSignal(unittest.TestCase):
-    def test_socket_args(self):
-        s = Signal()
+    def test_signal(self):
+        def noargs():
+            pass
 
-        def two(a, b):
-            self.assertEqual(a, 1)
-            self.assertEqual(b, 2)
+        def arg1(a):
+            pass
 
-        s.connect(two)
-        s.emit(1, 2, 3)
-        s.emit(1, 2)
-        with self.assertRaises(TypeError):
+        def arg2(a, b):
+            pass
+
+        def arg2def1(a, b, c=1):
+            pass
+
+        def arg2kwargs(a, b, **kwargs):
+            pass
+
+        def args(*args):
+            pass
+
+        def kwargs(**kwargs):
+            pass
+
+        def argskwargs(*args, **kwargs):
+            pass
+
+        s = Signal()  # no args or kwargs
+        for f in (noargs, args, argskwargs, kwargs):
+            s.connect(f)
+        for f in (arg1, arg2, arg2def1, arg2kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit()
+        with self.assertRaises(SignalError):
             s.emit(1)
-        s.disconnect()
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
 
-        def vargs(*args):
-            for a in args:
-                self.assertEqual(a, len(args))
-
-        s.connect(vargs)
+        s = Signal(nargs=1)
+        for f in (arg1, args, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg2, arg2def1, arg2kwargs, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
         s.emit(1)
-        s.emit(2, 2)
-        s.emit(3, 3, 3)
+        with self.assertRaises(SignalError):
+            s.emit()
+        with self.assertRaises(SignalError):
+            s.emit(1, 2)
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
+
+        s = Signal(nargs=2)
+        for f in (arg2, arg2def1, arg2kwargs, args, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg1, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit(1, 2)
+        with self.assertRaises(SignalError):
+            s.emit()
+        with self.assertRaises(SignalError):
+            s.emit(1)
+        with self.assertRaises(SignalError):
+            s.emit(1, 2, 3)
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
+
+        s = Signal(nargs=3)
+        for f in (arg2def1, args, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, arg2kwargs, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit(1, 2, 3)
+        with self.assertRaises(SignalError):
+            s.emit()
+        with self.assertRaises(SignalError):
+            s.emit(1, 2)
+        with self.assertRaises(SignalError):
+            s.emit(1, 2, 3, 4)
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
+
+        s = Signal(nargs=4)
+        for f in (args, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, arg2def1, arg2kwargs, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit(1, 2, 3, 4)
+        with self.assertRaises(SignalError):
+            s.emit()
+        with self.assertRaises(SignalError):
+            s.emit(1, 2, 3)
+        with self.assertRaises(SignalError):
+            s.emit(1, 2, 3, 4, 5)
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
+
+        s = Signal(varargs=True)
+        for f in (args, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, arg2def1, arg2kwargs, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit()
+        s.emit(1)
+        s.emit(1, 2)
+        with self.assertRaises(SignalError):
+            s.emit(a=1)
+
+        s = Signal(varkwargs=True)
+        for f in (argskwargs, kwargs):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, arg2def1, arg2kwargs, args):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit()
+        s.emit(a=1)
+        with self.assertRaises(SignalError):
+            s.emit(1)
+        with self.assertRaises(SignalError):
+            s.emit(1, 2)
+
+        s = Signal(varargs=True, varkwargs=True)
+        for f in (argskwargs, ):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, arg2def1, arg2kwargs,
+                  args, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit()
+        s.emit(1)
+        s.emit(1, a=1)
+        s.emit(a=1)
+
+        s = Signal(nargs=2, kwargs=['c'])
+        for f in (arg2def1, arg2kwargs, argskwargs):
+            s.connect(f)
+        for f in (noargs, arg1, arg2, args, kwargs):
+            with self.assertRaises(SignalError):
+                s.connect(f)
+        s.emit(1, 2)
+        s.emit(1, 2, c=3)
+        with self.assertRaises(SignalError):
+            s.emit(1)
+        with self.assertRaises(SignalError):
+            s.emit(1, 2, d=4)
+        with self.assertRaises(SignalError):
+            s.emit(c=3)
 
     def test_socket_args_through_proxy(self):
         # open proxy serving Example

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from pizco.util import bind
+from pizco.util import bind, Signal
 
 
 class MockSocket(object):
@@ -13,6 +13,14 @@ class MockSocket(object):
         return 42
 
 
+class Example(object):
+    def __init__(self):
+        self.signal = Signal()
+
+    def emit(self, *args):
+        self.signal.emit(*args)
+
+
 class TestProtocol(unittest.TestCase):
     def test_bind_address(self):
 
@@ -22,6 +30,37 @@ class TestProtocol(unittest.TestCase):
         self.assertEqual(bind(mock, ('127.0.0.1', 5000)), 'tcp://127.0.0.1:5000')
         self.assertEqual(bind(mock, ('127.0.0.1', 0)), 'tcp://127.0.0.1:42')
         self.assertEqual(bind(mock, 'inproc://bla'), 'inproc://bla')
+
+
+class TestSignal(unittest.TestCase):
+    def test_socket_args(self):
+        s = Signal()
+
+        def two(a, b):
+            self.assertEqual(a, 1)
+            self.assertEqual(b, 2)
+
+        s.connect(two)
+        s.emit(1, 2, 3)
+        s.emit(1, 2)
+        with self.assertRaises(TypeError):
+            s.emit(1)
+        s.disconnect()
+
+        def vargs(*args):
+            for a in args:
+                self.assertEqual(a, len(args))
+
+        s.connect(vargs)
+        s.emit(1)
+        s.emit(2, 2)
+        s.emit(3, 3, 3)
+
+    def test_socket_args_through_proxy(self):
+        # open proxy serving Example
+        # have it emit a 1 arg signal
+        # watch if it becomes 3 args
+        pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've added a new Signal class that takes a spec on creation and verifies that attached callbacks meet the spec on connect. Emit args are also checked against the spec prior to calling the callbacks. Also added a SignalError class that is raised when any of the above checks fail.

This required a bit of code modification as Signals need to be handled specially by the proxy. One possible way to get around needed to modify code code for this situation (and other possible special objects). Might be to look for a particular attribute in a handled object (maybe **pizcoify**) which would indicate to the proxy that this object requires special treatment. I'll make a separate issue where this can be discussed.

I also added a bugfix to Agent.notications_callbacks. Sometimes when the tests were run (maybe 1/5 times). I would get an error:

> File "pizco/pizco/agent.py", line 372, in _on_notification
>     callback = self.notifications_callbacks[(sender, topic)]
> KeyError: (u'tcp://127.0.0.1:6008', u'rw_prop_changed')

I tracked this down to unsubscribe removing the callback, queuing up _unsubscribe inside the ioloop, but the loop first responding to an incoming message and trying to call a non-existent callback. Now, the default callback will be called.
